### PR TITLE
adding service_restart parameter to specify a reload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@
       stats_auth_pass   => 'haproxy',
     }
 
+### Specify a different command for reloading HAProxy instead of restarting.
+
+    class { 'haproxy':
+      service_hasrestart => false,
+      service_restart    => '/usr/sbin/service haproxy reload'
+    }
 
 ## Unit testing
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,9 @@
 # $service_name::           Specify the name of the init script.
 #                           Default: operating system specific.
 #
+# $service_restart::        Specify a different restart command for reloads.
+#                           Default: operating system specific.
+#
 # $stats_auth_enable::      Enable/disable authentication for stats page.
 #                           Default: false.
 #
@@ -176,6 +179,7 @@ class haproxy (
   $service_hasrestart   = $::haproxy::params::service_hasrestart,
   $service_hasstatus    = $::haproxy::params::service_hasstatus,
   $service_name         = $::haproxy::params::service_name,
+  $service_restart      = $::haproxy::params::service_restart,
   $stats_auth_enable    = $::haproxy::params::stats_auth_enable,
   $stats_auth_pass      = $::haproxy::params::stats_auth_pass,
   $stats_auth_user      = $::haproxy::params::stats_auth_user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class haproxy::params {
       $service_hasrestart = undef
       $service_hasstatus  = undef
       $service_name       = 'haproxy'
+      $service_restart    = undef
     }
 
     'Debian': {
@@ -79,6 +80,7 @@ class haproxy::params {
       $service_hasrestart = true
       $service_hasstatus  = true
       $service_name       = 'haproxy'
+      $service_restart    = undef
     }
 
     default: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,7 @@ class haproxy::service {
       enable     => $::haproxy::service_enable,
       hasrestart => $::haproxy::service_hasrestart,
       hasstatus  => $::haproxy::service_hasstatus,
+      restart    => $::haproxy::service_restart,
       require    => [
         Service['::haproxy::service_dep'],
         Class['::haproxy::config'],
@@ -26,6 +27,7 @@ class haproxy::service {
       enable     => $::haproxy::service_enable,
       hasrestart => $::haproxy::service_hasrestart,
       hasstatus  => $::haproxy::service_hasstatus,
+      restart    => $::haproxy::service_restart,
       require    => Class['::haproxy::config'];
     }
   }


### PR DESCRIPTION
the haproxy service resource only supports start/stop/restart
you can get around this by setting in the service resource:
  hasrestart => false
then specifying a different restart command:
  restart => '/usr/bin/service haproxy reload'
