### PR TITLE
Added ability to add custom logging options to manage log fields.

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -57,6 +57,7 @@ define haproxy::instance (
   $instance        = 'listen',
   $mode            = 'http',
   $option          = [ 'httpclose' ],
+  $capture         = undef,
   $server          = undef,
 ) {
   case $instance {

--- a/templates/instance_frontend.erb
+++ b/templates/instance_frontend.erb
@@ -4,5 +4,10 @@ frontend <%= @name %>
 <% @option.each do |option| -%>
 	option          <%= option %>
 <% end -%>
+<% if @capture %>
+  <% @capture.each do |capture| -%>
+	capture         <%= capture %>
+  <% end -%>
+<% end -%>
 	default_backend <%= @default_backend %>
 


### PR DESCRIPTION
This feature was needed by logstash patterns (https://github.com/elasticsearch/logstash/blob/master/patterns/haproxy)

As result option can be used like this:

``` puppet
    capture => [
      'request header Host len 40',
      'request header X-Forwarded-For len 50',
      'request header Accept-Language len 50',
      'request header Referer len 200',
      'request header User-Agent len 200',
      'response header Content-Type len 30',
      'response header Content-Encoding len 10',
      'response header Cache-Control len 200',
      'response header Last-Modified len 200',
    ],
```

Also, if this parameter is not specified, no action with config file is performed.
I think it will be useful to add check for "option" too and do not include default value if it don't needed. For now is adds unneeded in some cases 'httpclose' option by default.
